### PR TITLE
多个节点的部署是并行的，改成串行

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,9 +186,16 @@ module.exports = function(arr_options, modified, total, callback) {
       handleSingle(arr_options,modified,total,callback);
   }
   else{
-    arr_options.__pos.forEach(function(item){
-      handleSingle(item,modified,total,callback);
+    var steps = arr_options.__pos.map(function(item){
+      return function(callback){
+        handleSingle(item, modified, total, callback);
+      }
     });
+    _.reduceRight(steps, function(next, current){
+      return function(){
+        current(next);
+      }
+    }, callback)();
   }
 };
 function handleSingle(options, modified, total, callback){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fis3-deploy-http-push-strong",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "fis3 deploy http-push-plus plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fis.plugin("http-push-strong", [{
                    receiver: first.receiver,
                    to: first.to,
                    from: first.from
                }, {
                    receiver: second.receiver,
                    to: second.to,
                    from: second.from
                }]);

second与one是并发执行的，不便于控制流程，如：1，某文件出错，需要终止  2，前后存在依赖关系，应该先部署one，后部署two